### PR TITLE
Adding a setTimeout as inline with other docs/examples about the api,…

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ module.exports = function(params, callback) {
         if (nonceResponse.nonce) {
             // console.log(nonceResponse);
             parameters.headers = authHeaders(parameters.consumer_key, nonceResponse.nonce);
-            callElucidat(parameters, callback);
+            setTimeout(callElucidat(parameters, callback), 250);
             
         } else {
             callback(403, 'Error getting nonce...');


### PR DESCRIPTION
… we need to give the server time to update before calling it again.  If this code is called on a fast computer (eg the amazon ones we use with serverless) the api is hit again before its been properly updated and causes a failure in the call